### PR TITLE
Verify functionality of webp and jpeg2k. 

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -43,4 +43,4 @@ the source, you probably know what you're doing and just do something among
 the lines of the Linux steps.
 
 The binary package can be built using PyInstaller, using the command:
-pyinstaller quivi.spec --noconsole
+set PYTHONOPTIMIZE=1 && pyinstaller quivi.spec --noconsole --noconfirm

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This fork was made with the primary purpose of adding 64-bit compatibility. The 
 
 No new features have been added, but the upgrade to Python 3 offers better support for Unicode filenames, and the 64bit environment supports larger images.
 
+Upgrading the image libraries offers support for some newer formats, including Webp.
+
 # Porting progress
 - Updated to support Python 3.8.1
 - wx updated to 4.1.1

--- a/quivilib/meta.py
+++ b/quivilib/meta.py
@@ -25,15 +25,18 @@ else:
     LOG_LEVEL = logging.ERROR
 DOUBLE_BUFFERING = True
 
+#GDI is used to speed up image processing on Windows. Roughly 10% faster from my tests.
+#However, it only supports basic image types and does not support files within zip archives.
+#Cairo would be used for the same on Linux, but I haven't been able to get it to work.
 if sys.platform == 'win32':
     USE_FREEIMAGE = True
-    USE_PIL = True
-    USE_GDI_PLUS = True
+    USE_PIL = False
+    USE_GDI_PLUS = False
     USE_CAIRO = False
     PATH_SEP = ';'
 else:
     USE_FREEIMAGE = True
-    USE_PIL = False
+    USE_PIL = True
     USE_GDI_PLUS = False
     USE_CAIRO = False
     PATH_SEP = ':'

--- a/quivilib/model/canvas.py
+++ b/quivilib/model/canvas.py
@@ -52,8 +52,14 @@ class Canvas(object):
         self.view = view
         
     def load(self, f, path, adjust=True, delay=False):
-        img = image.open(f, str(path), self.__class__, delay)
+        if __debug__:
+            import time
+            start = time.perf_counter()
+        img = image.open(f, path, self.__class__, delay)
         self.load_img(img, adjust)
+        if __debug__:
+            stop = time.perf_counter()
+            log.debug(f'{path.name} took: {(stop - start)*1000:0.1f}ms.')
         
     def load_img(self, img, adjust=True):
         self.img = img

--- a/quivilib/model/image/__init__.py
+++ b/quivilib/model/image/__init__.py
@@ -32,10 +32,13 @@ def get_supported_extensions():
         from pyfreeimage import library
         exts += library.load().get_readable_extensions()
     if meta.USE_PIL:
-        exts += ['.bmp', '.cur', '.dcx', '.fli', '.flc', '.fpx', '.gbr', '.gif',
-                 '.ico', '.im', '.imt', '.jpg', '.jpeg', '.pcd', '.pcx', '.png',
+        #PIL.Image.registered_extensions(). This is a curated list.
+        exts += ['.bmp', '.cur', '.dcx', '.fli', '.flc', '.fpx', '.gbr', '.gif', 
+                 '.ico', '.im', '.imt', '.jpg', '.jpeg', '.pcd', '.pcx', '.png', '.apng',
+                 #JPEG 2000. No JPEG XL support yet.
+                 '.j2c', '.j2k', '.jfif', '.jp2', '.jpc', '.jpe', '.jpf', '.jpx',
                  '.ppm', '.pbm', '.pgm', '.sgi', '.tga', '.tif', '.tiff', '.xmb',
-                 '.xpm']
+                 '.webp', '.xpm']
     return list(set(exts))
 
 supported_extensions = get_supported_extensions()
@@ -43,9 +46,13 @@ supported_extensions = get_supported_extensions()
 
 
 def open(f, path, canvas_type, delay=False):
+    ext = path.suffix
     for cls in IMG_CLASSES:
+        if not ext in cls.extensions():
+            log.debug(f"Skip {cls} - no support for {ext}")
+            continue
         try:
-            img = cls(canvas_type, f, path, delay=delay)
+            img = cls(canvas_type, f, str(path), delay=delay)
             break
         except Exception as e:
             if IMG_CLASSES[-1] is cls:

--- a/quivilib/model/image/freeimage.py
+++ b/quivilib/model/image/freeimage.py
@@ -156,6 +156,12 @@ class FreeImage(object):
         else:
             bmp = img.convert_to_wx_bitmap(wx)
             return bmp
-                
+
+    def _get_extensions():
+        return fi.library.load().get_readable_extensions()
+    ext_list = _get_extensions()
+    def extensions():
+        return FreeImage.ext_list
+
     def close(self):
         pass

--- a/quivilib/model/image/gdiplus.py
+++ b/quivilib/model/image/gdiplus.py
@@ -62,13 +62,16 @@ class GdiPlusImage(object):
         if img is None:
             #TODO: load from f
             try:
+                #Note - this will only work if path is a real file, and not an archive entry.
                 img = _GdiPlusInnerImage(path=path)
             except EnvironmentError:
                 if not f:
                     raise
                 fs = util.FileStream(f)
                 istream = util.wrap(fs, pythoncom.IID_IStream)
-                img = _GdiPlusInnerImage(isttream=path)
+                #"ctypes.ArgumentError: argument 1: Don't know how to convert parameter 1"
+                #If this ever worked, it's dead now.
+                img = _GdiPlusInnerImage(istream=istream)
         
         width = ctypes.c_uint()
         gdiplus.GdipGetImageWidth(img.img, ctypes.byref(width))
@@ -82,6 +85,11 @@ class GdiPlusImage(object):
         self.zoomed_bmp = None
         self.delay = delay
         self.rotation = 0
+    
+    def extensions():
+        #Taken from https://docs.microsoft.com/en-us/windows/win32/api/gdiplusheaders/nf-gdiplusheaders-image-image(constwchar_bool)
+        #Webp (and possibly others) don't work but should. They display in Paint, which I understand is basically a wrapper around GDI.
+        return ['.bmp', '.emf', '.gif', '.jpg', '.jpeg', '.png', '.tiff']
         
     @property
     def width(self):

--- a/quivilib/model/image/pil.py
+++ b/quivilib/model/image/pil.py
@@ -5,6 +5,8 @@ from quivilib.util import rescale_by_size_factor
 from PIL import Image
 import logging
 log = logging.getLogger('pil')
+#PIL has its own logging that's typically not relevant.
+logging.getLogger("PIL").setLevel(logging.ERROR)
 
 import wx
 
@@ -108,6 +110,13 @@ class PilImage(object):
         bmp = wx.Bitmap.FromBuffer(width, height, img.tobytes())
         #TODO: Implement delayed_fn. See freeimage.
         return bmp
+
+    def _get_extensions():
+        return list(Image.registered_extensions().keys())
+    ext_list = _get_extensions()
+    
+    def extensions():
+        return PilImage.ext_list
 
     def close(self):
         pass


### PR DESCRIPTION
This resulted in more investigation into the image handlers and ultimately dropping gdi. The win32 com support wasn't creating an IStream; no idea if this ever worked or not. Given that the speed improvement is only around 10% from my (quick) test, and not the ~300% improvement in the past, I don't think this is a big loss.