### PR TITLE
Add encoding to the logger. 

### DIFF
--- a/quivilib/control/main.py
+++ b/quivilib/control/main.py
@@ -49,14 +49,14 @@ class MainController(object):
             pass
         
         if meta.DEBUG:
-            log.basicConfig()
+            log.basicConfig(encoding='utf8')
             log_file = Path(wx.StandardPaths.Get().GetUserDataDir()) / self.LOG_FILE_NAME
-            fh = log.FileHandler(log_file, mode='w')
+            fh = log.FileHandler(log_file, mode='w', encoding='utf8')
             fh.setLevel(meta.LOG_LEVEL)
             log.getLogger().addHandler(fh)
         else:
             log_file = Path(wx.StandardPaths.Get().GetUserDataDir()) / self.LOG_FILE_NAME
-            log.basicConfig(filename=log_file, filemode='w')
+            log.basicConfig(filename=log_file, filemode='w', encoding='utf8')
         log.getLogger().setLevel(meta.LOG_LEVEL)
         
         wx.ArtProvider.Push(QuiviArtProvider())

--- a/tests/unittests/check_update_test.py
+++ b/tests/unittests/check_update_test.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 from pubsub import pub as Publisher 
 
 import logging
-logging.basicConfig()
+logging.basicConfig(encoding='utf8')
 logging.getLogger().setLevel(logging.DEBUG)
 
 DOWN_URL = 'http://example.com/down'


### PR DESCRIPTION
Fixes issues when the message contains characters outside current code page, e.g. unicode filenames