### PR TITLE
Debug window

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This fork was made with the primary purpose of adding 64-bit compatibility. The 
     - The intent is for when viewing standard page images that includes image files that are two physical pages joined together, i.e. full-page spreads. This _should_ keep the zoom level roughly consistent with the rest of the book.
     - This will lead to false positive if viewing landscape pages, or any digital art that doesn't try to adhere to a standard page layout. It can be toggled via a hotkey. This will automatically resize the image.
     - There's no indication that this is being done while in fullscreen, so if two pages are joined together but don't have shared art and contain ample margins, it will be easy to accidentally skip pages.
+- Increased the size of the image cache to better account for modern hardware (it's still hardcoded and doesn't check system RAM available or anything).
 
 
 # Removed features

--- a/quivilib/control/cache.py
+++ b/quivilib/control/cache.py
@@ -21,6 +21,9 @@ log.setLevel(logging.ERROR)
 
 
 class ImageCacheLoadRequest(object):
+    """ Data class containing the necessary information for loading an image
+    i.e. the physical path and, after it has been loaded, the image itself.
+    """
     def __init__(self, container, item, view):
         self.container = container
         self.item = item
@@ -84,6 +87,10 @@ class ImageCache(object):
                     log.debug('main: cache hit')
                     self.notify_image_loaded(req)
                     hit = True
+                    #Remove and then re-add the request so it is at the back of the queue.
+                    self.cache.remove(req)
+                    self.cache.insert(0, req)
+                    break
         if not hit and request != self.processing_request:
             log.debug('main: cache miss')
             self._put_request(request)
@@ -95,6 +102,7 @@ class ImageCache(object):
             if len(self.cache) >= meta.CACHE_SIZE:
                 removed = self.cache.pop()
                 self.notify_cache_removed(removed)
+                log.debug(f'main: removed cache {removed.path}')
             self.cache.insert(0, request)
             request.img.delayed_load()
             self.notify_image_loaded(request)

--- a/quivilib/control/debug.py
+++ b/quivilib/control/debug.py
@@ -8,8 +8,12 @@ class DebugController(object):
         self.control = control
         #self.model = model
         #Subscribe to cache events.
-        #Publisher.subscribe(self.on_cache_image_loaded, 'cache.image_loaded')
-        #Publisher.subscribe(self.on_cache_image_load_error, 'cache.image_load_error')
+        #Messages will be handled even if the window isn't open.
+        #Publisher.subscribe(self.on_queue_change, 'debug.queue_changed')
+        #Publisher.subscribe(self.on_cache_change, 'debug.cache_changed')
+        
+        #Is there an easy way to put all the list item stuff here?
+        self.queue_data = {}
         
     def open_debug_cache_dialog(self):
         #Currently no parameters.

--- a/quivilib/control/debug.py
+++ b/quivilib/control/debug.py
@@ -1,0 +1,16 @@
+from pubsub import pub as Publisher
+
+
+
+
+class DebugController(object):
+    def __init__(self, control):
+        self.control = control
+        #self.model = model
+        #Subscribe to cache events.
+        #Publisher.subscribe(self.on_cache_image_loaded, 'cache.image_loaded')
+        #Publisher.subscribe(self.on_cache_image_load_error, 'cache.image_load_error')
+        
+    def open_debug_cache_dialog(self):
+        #Currently no parameters.
+        Publisher.sendMessage('debug.open_cache_dialog', params=None)

--- a/quivilib/control/file_list.py
+++ b/quivilib/control/file_list.py
@@ -132,7 +132,7 @@ class FileListController(object):
                     if idx > 0 and idx < len(container.items) and container.items[idx].typ == ItemType.IMAGE:
                         request = ImageCacheLoadRequest(container, container.items[idx], self.model.canvas.view)
                         log.debug(f"fl: requesting prefetch of {idx}")
-                        Publisher.sendMessage('cache.load_image', request=request)
+                        Publisher.sendMessage('cache.load_image', request=request, preload=True)
                         log.debug("fl: prefetch requested")
                 log.debug("fl: done")
             else:

--- a/quivilib/control/main.py
+++ b/quivilib/control/main.py
@@ -16,6 +16,7 @@ from quivilib.control.menu import MenuController
 from quivilib.control.canvas import CanvasController
 from quivilib.control.wallpaper import WallpaperController
 from quivilib.control.options import OptionsController
+from quivilib.control.debug import DebugController
 from quivilib.control.cache import ImageCache
 from quivilib.control.check_update import UpdateChecker
 from quivilib.control.i18n import I18NController
@@ -81,6 +82,11 @@ class MainController(object):
                                        self.view.canvas_view, self.settings)
         self.wallpaper = WallpaperController(self.model)
         self.options = OptionsController(self, self.model)
+        
+        self.debugController = None
+        if __debug__:
+            self.debugController = DebugController(self.model)
+        
         #This must be the last controller created (it references the others)
         self.menu = MenuController(self, self.settings)
         

--- a/quivilib/control/menu.py
+++ b/quivilib/control/menu.py
@@ -317,7 +317,7 @@ class MenuController(object):
          make_category(3, 'fav' , _('F&avorites'), favorites_menu),
          make_category(4, 'help', _('&Help'), help_menu),
          #make_category(5, _('Move'), hidden_menu, True),
-         make_category(6, '_fit', _('Fit'), fit_menu, True)
+         make_category(6, '_fit', _('Fit'), fit_menu, True),
         )
         #The fit menu doesn't appear in the top, but can open via right click, so it needs to be created.
         #The other menus here exist to provide commands in the options, but aren't otherwise menus
@@ -327,6 +327,19 @@ class MenuController(object):
             make_category(3.1, '_fav', _('Favorites'), favorites_hidden_menu, True),
             make_category(5, '_mov', _('Move'), hidden_menu, True),
         )
+        if __debug__:
+            #Debug options. Disable when built as an application.
+            #Nothing here will be translated, and won't be available as shortcuts.
+            debug_menu = (
+                make(29900, 'Cache', 'Show Cache information',
+                     control.debugController.open_debug_cache_dialog,
+                     [], flags=Command.KB),
+                #Maybe an option to change the log level?
+                #I can't find any kind of built in wxpython diagnostics that would be trivial to include.
+            )
+            main_menu = main_menu + (
+                make_category(7, 'debug', 'Debug', debug_menu),
+            )
         
         return main_menu, command_cats, commands
     

--- a/quivilib/gui/debug.py
+++ b/quivilib/gui/debug.py
@@ -1,0 +1,51 @@
+#TODO: (2,2) Improve: change the command listbox into a listctrl with columns:
+#    (Category / Command / Assigned shortcuts)
+
+import wx
+from pubsub import pub as Publisher
+
+WINDOW_SIZE = (400, 480)
+
+class DebugDialog(wx.Dialog):
+    def __init__(self, parent):
+        # begin wxGlade: OptionsDialog.__init__
+        wx.Dialog.__init__(self, parent=parent, style=wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER)
+        
+        self.ok_button = wx.Button(self, wx.ID_OK, "&OK")
+
+        self.__set_properties()
+        self.__do_layout()
+        
+        #Do this after do_layout for GetBestSize() to work.
+        bestsize = self.GetBestSize()
+        self.SetSize(max(bestsize[0], WINDOW_SIZE[0]), max(bestsize[1], WINDOW_SIZE[1]))
+        self.Centre()
+
+    def __set_properties(self):
+        # begin wxGlade: OptionsDialog.__set_properties
+        self.SetTitle("Debug information")
+        # end wxGlade
+        
+        self.ok_button.SetDefault()
+
+    def __do_layout(self):
+        # begin wxGlade: OptionsDialog.__do_layout
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        
+        self.Layout()
+        # end wxGlade
+
+
+    def on_ok(self, event): # wxGlade: OptionsDialog.<event_handler>
+        event.Skip()
+
+    def on_cancel(self, event): # wxGlade: OptionsDialog.<event_handler>
+        event.Skip()
+        
+# end of class OptionsDialog
+
+
+if __name__ == '__main__':
+    app = wx.App(False)
+    dlg = DebugDialog(None)
+    dlg.ShowModal()

--- a/quivilib/gui/debug.py
+++ b/quivilib/gui/debug.py
@@ -1,16 +1,29 @@
-#TODO: (2,2) Improve: change the command listbox into a listctrl with columns:
-#    (Category / Command / Assigned shortcuts)
+#Debug window. Should only be referenced when running through the command line.
 
+import os
 import wx
 from pubsub import pub as Publisher
 
 WINDOW_SIZE = (400, 480)
 
+#Meaningful text in the grid. Other items may be used but don't have a special meaning.
+QUEUED = 'Queued'
+LOADED = 'Loaded'
+
+
 class DebugDialog(wx.Dialog):
+    """Debug window for showing some application information.
+    Unlike most windows, this will always exist and is shown/hidden.
+    This is because the cache list form listens to events directly.
+    Probably a bad idea but this is a debug thing, so I'm not too concerned.
+    """
     def __init__(self, parent):
         # begin wxGlade: OptionsDialog.__init__
-        wx.Dialog.__init__(self, parent=parent, style=wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER)
+        wx.Dialog.__init__(self, parent=parent, style=wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER|wx.DIALOG_NO_PARENT|wx.STAY_ON_TOP)
         
+        #Information on loaded/cached images.
+        self.cache_list = DebugListCtrl(self)
+        #Maybe another control for showing (relevant) messages?
         self.ok_button = wx.Button(self, wx.ID_OK, "&OK")
 
         self.__set_properties()
@@ -20,6 +33,8 @@ class DebugDialog(wx.Dialog):
         bestsize = self.GetBestSize()
         self.SetSize(max(bestsize[0], WINDOW_SIZE[0]), max(bestsize[1], WINDOW_SIZE[1]))
         self.Centre()
+        
+        self.Bind(wx.EVT_BUTTON, self.on_ok_click, self.ok_button)
 
     def __set_properties(self):
         # begin wxGlade: OptionsDialog.__set_properties
@@ -30,20 +45,171 @@ class DebugDialog(wx.Dialog):
 
     def __do_layout(self):
         # begin wxGlade: OptionsDialog.__do_layout
-        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self.cache_list)
+        sizer.Add(self.ok_button)
+        self.SetSizer(sizer)
         
         self.Layout()
         # end wxGlade
 
 
-    def on_ok(self, event): # wxGlade: OptionsDialog.<event_handler>
-        event.Skip()
+    def on_ok_click(self, event): # wxGlade: OptionsDialog.<event_handler>
+        #event.Skip()
+        #This window needs to always be alive; don't destroy it.
+        self.Hide()
 
-    def on_cancel(self, event): # wxGlade: OptionsDialog.<event_handler>
-        event.Skip()
+
+# end of class DebugDialog
+
+class DebugListCtrl(wx.ListCtrl):
+    """ List view of the images known to the cache. Listens to the same events the cache does, plus
+    events emitted by the cache. Uses this to roughly duplicate the cache behavior.
+    It's not exact - items dropped from the cache are kept in the list but marked as removed.
+    This also means it won't actually show what's _really_ happening with the cache, which is unfortunate.
+    """
+    column_order = ['id', 'filename', 'queue', 'cache', 'resolution']
+    column_headers = ['', 'File', 'Queue', 'Cache', 'Resolution']
+    def __init__(self, parent):
+        wx.ListCtrl.__init__(
+            self, parent, -1, 
+            style=wx.LC_REPORT|wx.LC_SINGLE_SEL|wx.LC_SORT_ASCENDING
+            )
+        for i in range(len(DebugListCtrl.column_headers)):
+            self.InsertColumn(i, DebugListCtrl.column_headers[i])
+        self.SetColumnWidth(0, 20)
+        self.SetColumnWidth(1, 240)
+        self.SetColumnWidth(2, 80)
+        self.SetColumnWidth(3, 80)
+        self.SetColumnWidth(4, 200)
         
-# end of class OptionsDialog
-
+        #Dictionary of the Cache and Queue data. Updated based on messages;
+        #either the same ones that the Cache worker responds to, or the outgoing messages
+        #(Including at least one debug message that is only sent for this control)
+        #Key will be the full path.
+        self.cache_data = {}
+        #Alternative lookup table. Needed for sorting.
+        self.cache_data_id = {}
+        
+        #Messages the cache listens for
+        Publisher.subscribe(self.on_load_image, 'cache.load_image')
+        Publisher.subscribe(self.on_clear_pending, 'cache.clear_pending')
+        Publisher.subscribe(self.on_flush, 'cache.flush')
+        #Publisher.subscribe(self.on_program_closed, 'program.closed')  #This really doesn't matter.
+        
+        #Messages sent by the cache
+        Publisher.subscribe(self.on_cache_image_loaded, 'cache.image_loaded')
+        Publisher.subscribe(self.on_cache_image_load_error, 'cache.image_load_error')
+        Publisher.subscribe(self.on_cache_image_removed, 'cache.image_removed')
+    #
+    
+    def get_or_insert(self, request):
+        path = request.path
+        if path in self.cache_data:
+            return self.cache_data[path]
+        entry = {
+            'id': 0,
+            'path': request.path,
+            'filename': os.path.basename(request.path),
+            'queue': QUEUED,
+            'cache': '',
+            'resolution': '',
+        }
+        self.add_list_item(entry)
+        self.cache_data[path] = entry
+        self.cache_data_id[entry['id']] = entry
+        return entry
+    def add_list_item(self, entry):
+        """ Add an entry to the actual list control.
+        Modifies the entry object to include the id; use this for future requests
+        """
+        #I want this to display the numeric index of the list; I guess this is just how to do it.
+        index = self.InsertItem(self.GetItemCount(), str(self.GetItemCount()))
+        self.SetItemData(index, index)  #Must be an int.
+        entry['id'] = index
+        
+        self.update_list_item(entry)
+    def update_list_item(self, entry):
+        """ Update the list control with the new values.
+        """
+        index = entry['id']
+        for i in range(len(DebugListCtrl.column_order)):
+            key = DebugListCtrl.column_order[i]
+            self.SetItem(index, i, str(entry[key]))
+        #This causes problems with updating the data. It is modifying the actual index, not just the display order.
+        #self.SortItems(self.sort_fn)
+    
+    def sort_fn(self, id1, id2):
+        """ Special sort order - put loaded images first.
+        Not using the built-in mixin because I think that's primarily for "direct" sorting.
+        """
+        if id2 not in self.cache_data_id:
+            #I guess this function can be called for records that don't exist. Well that's fun.
+            return 0
+        item1 = self.cache_data_id[id1]
+        item2 = self.cache_data_id[id2]
+        k1 = self.sort_key(item1)
+        k2 = self.sort_key(item2)
+        if (k1 != k2):
+            return k1 - k2
+        #Equal priority; sort by id
+        return item1['id'] - item2['id']
+    def sort_key(self, item):
+        """ Helper function for sorting; convert text strings to priorities.
+        If priorities match, sort_fn will use id. Otherwise higher-priority items are always first.
+        """
+        if item['cache'] is LOADED:
+            return 1100
+        if item['cache'] != '':
+            return 1000
+        if item['queue'] is QUEUED:
+            return 110
+        if item['queue'] != '':
+            return 100
+        return 0
+        
+    
+    #Events
+    def on_load_image(self, *, request):
+        """ Cache uses this to add an entry to the Queue.
+        It will load the image and add it to the cache, then send cache.image_loaded
+        """
+        entry = self.get_or_insert(request)
+        entry['queue'] = QUEUED
+        self.update_list_item(entry)
+        pass
+    def on_clear_pending(self, *, request=None):
+        #I think this means any queued-but-not-cached items are dropped.
+        for x in self.cache_data:
+            entry = self.cache_data[x]
+            if entry['queue'] == QUEUED:
+                entry['queue'] = 'Abandoned'
+                self.update_list_item(entry)
+        pass
+    def on_flush(self):
+        print("on_flush called.")
+        #Presumably a new container was loaded, so all old cache entries are meaningless.
+        #self.cache_data.clear()
+        #self.cache_data_id.clear()
+        #self.cache_keys.clear()
+        #TODO: Update list items.
+        pass
+    def on_cache_image_loaded(self, *, request):
+        """Sent by the cache when an image is loaded.
+        """
+        entry = self.get_or_insert(request)
+        entry['queue'] = ''
+        entry['cache'] = LOADED
+        self.update_list_item(entry)
+    def on_cache_image_load_error(self, *, request, exception, tb):
+        entry = self.get_or_insert(request)
+        entry['queue'] = ''
+        entry['cache'] = 'Failed'
+        self.update_list_item(entry)
+    def on_cache_image_removed(self, *, request):
+        entry = self.get_or_insert(request)
+        entry['cache'] = 'Removed'
+        self.update_list_item(entry)
 
 if __name__ == '__main__':
     app = wx.App(False)

--- a/quivilib/gui/debug.py
+++ b/quivilib/gui/debug.py
@@ -180,7 +180,7 @@ class DebugListCtrl(wx.ListCtrl):
             txt = self.GetItemText(i, 0)
             self.sorted_indices[int(txt)] = i
     #Events
-    def on_load_image(self, *, request):
+    def on_load_image(self, *, request, preload=False):
         """ Cache uses this to add an entry to the Queue.
         It will load the image and add it to the cache, then send cache.image_loaded
         """

--- a/quivilib/gui/main.py
+++ b/quivilib/gui/main.py
@@ -11,6 +11,7 @@ from quivilib.i18n import _
 from quivilib import meta
 from quivilib.util import error_handler
 from quivilib.gui.file_list import FileListPanel
+from quivilib.gui.debug import DebugDialog
 from quivilib.resources import images
 from quivilib import util
 
@@ -105,6 +106,10 @@ class MainWindow(wx.Frame):
         Publisher.subscribe(self.on_canvas_fit_setting_changed, 'settings.loaded')
         Publisher.subscribe(self.on_canvas_fit_setting_changed, 'settings.changed.Options.FitType')
         Publisher.subscribe(self.on_canvas_fit_setting_changed, 'settings.changed.Options.FitWidthCustomSize')
+        
+        if __debug__:
+            #This is created immediately because it listens for messages.
+            self.dbg_dialog = DebugDialog(self)
         
         self._last_size = self.GetSize() 
         self._last_pos = self.GetPosition()
@@ -405,10 +410,10 @@ class MainWindow(wx.Frame):
         dialog.Destroy()
         
     def on_open_debug_cache_dialog(self, *, params):
-        from quivilib.gui.debug import DebugDialog
-        dialog = DebugDialog(self)
-        dialog.ShowModal()
-        dialog.Destroy()
+        if __debug__:
+            self.dbg_dialog.Show()       #Modeless
+            #dialog.Destroy()
+        #Do nothing in a release build
         
     def on_open_directory_dialog(self, *, req):
         dialog = wx.DirDialog(self, _('Choose a directory:'),

--- a/quivilib/gui/main.py
+++ b/quivilib/gui/main.py
@@ -95,6 +95,7 @@ class MainWindow(wx.Frame):
         Publisher.subscribe(self.on_settings_loaded, 'settings.loaded')
         Publisher.subscribe(self.on_open_wallpaper_dialog, 'wallpaper.open_dialog')
         Publisher.subscribe(self.on_open_options_dialog, 'options.open_dialog')
+        Publisher.subscribe(self.on_open_debug_cache_dialog, 'debug.open_cache_dialog')
         Publisher.subscribe(self.on_open_about_dialog, 'about.open_dialog')
         Publisher.subscribe(self.on_open_directory_dialog, 'file_list.open_directory_dialog')
         Publisher.subscribe(self.on_update_available, 'program.update_available')
@@ -400,6 +401,12 @@ class MainWindow(wx.Frame):
     def on_open_options_dialog(self, *, fit_choices, settings, categories, available_languages, active_language, save_locally):
         from quivilib.gui.options import OptionsDialog
         dialog = OptionsDialog(self, fit_choices, settings, categories, available_languages, active_language, save_locally)
+        dialog.ShowModal()
+        dialog.Destroy()
+        
+    def on_open_debug_cache_dialog(self, *, params):
+        from quivilib.gui.debug import DebugDialog
+        dialog = DebugDialog(self)
         dialog.ShowModal()
         dialog.Destroy()
         

--- a/quivilib/meta.py
+++ b/quivilib/meta.py
@@ -17,8 +17,8 @@ ORIG_AUTHOR_EMAIL = 'conradoplg@gmail.com'
 COPYRIGHT = f"Copyright (c) 2009, {ORIG_AUTHOR} <{ORIG_AUTHOR_EMAIL}>\nCopyright (c) 2022, {AUTHOR} <{AUTHOR_EMAIL}>\nAll rights reserved."
 
 CACHE_ENABLED = True
-CACHE_SIZE = 3
-PREFETCH_COUNT = 1
+CACHE_SIZE = 7
+PREFETCH_COUNT = 2
 if __debug__:
     DEBUG = True
     LOG_LEVEL = logging.DEBUG


### PR DESCRIPTION
Add a new debug window for inspecting the cache. This duplicates the behavior rather than directly inspecting it, but I don't know that there's a sensible way to do that. This will not be included in the packaged build, only when running via the command line.

Increase the size of the image cache and slightly modify the Keep behavior. This was the motivation for the debug window.