### PR TITLE
Split favorites and placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The 64-bit executable prevents issues with loading large files. The upgrade to P
     - (Optionally) Only a single place holder can be used for anything. Saving any new placeholder will replace the existing one.
     - (Optionally) Placeholders will be deleted upon opening.
     - (Optionally) Opening a folder/archive that has a placeholder will automatically load the placeholder.
+    - Placeholders and Favorites can optionally be separated into separate submenus of the Favorites menu on the menu bar. This is a configuration option in settings. Placeholders and favorites are also included in a right-click context menu and are always separated there.
 - Holding down shift while using the scrollwheel will scroll horizontally.
 - Holding down ctrl while using the scrollwheel zoom in/out on the mouse cursor's location (instead of the center of the image).
 - Added "Drag image" as an explicit command, instead of the default behavior of always dragging with left click. This means left click can be reassigned to a different action, such as Next image, and it will never attempt to move the image. The old behavior can be restored via an option in the Mouse tab.

--- a/quivilib/gui/components/menu_bar.py
+++ b/quivilib/gui/components/menu_bar.py
@@ -13,14 +13,15 @@ from quivilib.model.settings import Settings
 
 
 class QuiviMenuBar(wx.MenuBar):
-    def __init__(self, style = 0):
+    def __init__(self, style = 0) -> None:
         super().__init__(style)
 
         #List of (id, name) tuples. Filled on the favorites.changed event,
         #used in the file list popup menu
         self.favorites_menu_items: list[FavoriteMenuItem] = []
         self._favorite_menu_count = 0
-        self.update_menu_item = None
+        """Exists just to prevent adding the menubar item twice, which should be impossible anyway"""
+        self.update_menu = None
         #Track as a dictionary
         self.menus: dict[MenuName, wx.Menu] = {}
         self.menu_names: dict[MenuName, str] = {}
@@ -34,7 +35,6 @@ class QuiviMenuBar(wx.MenuBar):
         # Set by a background task if there is an update available.
         self.down_url: str | None = None
 
-        Publisher.subscribe(self.on_language_changed, 'language.changed')
         Publisher.subscribe(self.on_menu_built, 'menu.built')
         Publisher.subscribe(self.on_menu_labels_changed, 'menu.labels.changed')
         Publisher.subscribe(self.on_favorites_changed, 'favorites.changed')
@@ -85,7 +85,7 @@ class QuiviMenuBar(wx.MenuBar):
             elif type(cmd) is MenuName:
                 if cmd not in self.menus:
                     raise Exception(f"Menu {cmd} referenced before it was created.")
-                submenu = self.menus[cmd]
+                submenu: wx.Menu = self.menus[cmd]
                 data = all_menus[cmd]
                 _menu.AppendSubMenu(submenu, data.name)
             # Command
@@ -93,6 +93,7 @@ class QuiviMenuBar(wx.MenuBar):
                 command = cmd_lookup[cmd]
                 style = wx.ITEM_CHECK if command.checkable else wx.ITEM_NORMAL
                 wx_menuitem = _menu.Append(command.ide, command.name_and_shortcut, command.description, style)
+
                 #Track for later updates (i.e. translations).
                 self.all_cmd_pairs.append((command, wx_menuitem))
                 #If a cmd is in multiple menus, it will bind multiple times. Is this a problem?
@@ -103,9 +104,8 @@ class QuiviMenuBar(wx.MenuBar):
     def on_favorites_changed(self, *, favorites: Favorites, settings: Settings):
         favorites_menu = self.menus[MenuName.Favorites]
         fav_only = self.menus[MenuName.FavoritesSub]
-        fav_ctx = self.menus[MenuName.FavoritesCtx]
         place_only = self.menus[MenuName.PlaceholderSub]
-        place_ctx = self.menus[MenuName.PlaceholderCtx]
+        fav_dest = [fav_only, place_only]
         self._create_favorites(favorites)
         self.Freeze()
         try:
@@ -115,12 +115,7 @@ class QuiviMenuBar(wx.MenuBar):
                 favorites_menu.AppendSeparator()
             for item in self.favorites_menu_items:
                 favorites_menu.Append(item.ide, item.name)
-                if item.fav.is_placeholder():
-                    place_only.Append(item.ide, item.name)
-                    place_ctx.Append(item.ide, item.name)
-                else:
-                    fav_only.Append(item.ide, item.name)
-                    fav_ctx.Append(item.ide, item.name)
+                fav_dest[item.fav.is_placeholder()+0].Append(item.ide, item.name)
         finally:
             self.Thaw()
         pass
@@ -155,7 +150,7 @@ class QuiviMenuBar(wx.MenuBar):
         Call this within a 'freeze' block. """
         favorites_menu = self.menus[MenuName.Favorites]
 
-        reset_submenus = (self.menus[MenuName.FavoritesSub], self.menus[MenuName.PlaceholderSub], self.menus[MenuName.FavoritesCtx], self.menus[MenuName.PlaceholderCtx])
+        reset_submenus = (self.menus[MenuName.FavoritesSub], self.menus[MenuName.PlaceholderSub])
         for menu in reset_submenus:
             while menu.GetMenuItemCount() > 0:
                 item = menu.FindItemByPosition(0)
@@ -184,19 +179,16 @@ class QuiviMenuBar(wx.MenuBar):
             if midx != -1:
                 self.SetMenuLabel(midx, category.name)
 
-    # Update available menu
-    def on_language_changed(self):
-        if self.update_menu_item:
-            self.update_menu_item.SetItemLabel(_('&Download'))
-            self.update_menu_item.SetHelp(_('Go to the download site'))
-            self.SetMenuLabel(self.GetMenuCount()-1, _('&New version available!'))
-
     def on_update_available(self, *, down_url, check_time, version):
-        self.down_url = down_url
-        menu = self.menus[MenuName.Downloads]
-        menu_idx = self.GetMenuCount()
-        self.Append(menu, self.menu_names[MenuName.Downloads])
-        Publisher.sendMessage('menu.item_added', cmd=MenuName.Downloads, idx=menu_idx)
+        if not self.update_menu:
+            # (Shouldn't be possible, but don't try to add this twice)
+            self.down_url = down_url
+            menu = self.menus[MenuName.Downloads]
+            menu_idx = self.GetMenuCount()
+            self.update_menu = menu
+            self.Append(menu, self.menu_names[MenuName.Downloads])
+
+            Publisher.sendMessage('menu.item_added', cmd=MenuName.Downloads, idx=menu_idx)
 
     def do_download_update(self):
         Publisher.sendMessage('program.open_update_site', url=self.down_url)

--- a/quivilib/gui/components/menu_bar.py
+++ b/quivilib/gui/components/menu_bar.py
@@ -16,7 +16,8 @@ class QuiviMenuBar(wx.MenuBar):
     def __init__(self, style = 0) -> None:
         super().__init__(style)
 
-        self.use_split_favorites: bool|None = None
+        #The menubar is created as if this setting is False. Settings are then applied later.
+        self.use_split_favorites: bool = False
 
         #List of (id, name) tuples. Filled on the favorites.changed event,
         #used in the file list popup menu

--- a/quivilib/gui/components/menu_bar.py
+++ b/quivilib/gui/components/menu_bar.py
@@ -1,0 +1,215 @@
+import wx
+import wx.aui
+from pubsub import pub as Publisher
+
+from quivilib.i18n import _
+from quivilib.model import Favorites
+from quivilib.model.command import Command, CommandCategory
+from quivilib.model.commandenum import MenuName, CommandName
+from quivilib.model.favorites import FavoriteMenuItem
+from quivilib.model.settings import Settings
+
+
+class QuiviMenuBar(wx.MenuBar):
+    def __init__(self, style = 0):
+        super().__init__(style)
+
+        #List of (id, name) tuples. Filled on the favorites.changed event,
+        #used in the file list popup menu
+        self.favorites_menu_items: list[FavoriteMenuItem] = []
+        self._favorite_menu_count = 0
+        self.update_menu_item = None
+        #Track as a dictionary
+        self.menus: dict[MenuName, wx.Menu] = {}
+        self.menu_names: dict[MenuName, str] = {}
+        #Used for updating translations dynamically. Pair the actual wx objects and the local definitions.
+        self.all_cmd_pairs: list[tuple[Command, wx.MenuItem]] = []
+
+        self.accel_table = None
+
+        # Set by a background task if there is an update available.
+        self.down_url: str | None = None
+
+        Publisher.subscribe(self.on_language_changed, 'language.changed')
+        Publisher.subscribe(self.on_menu_built, 'menu.built')
+        Publisher.subscribe(self.on_menu_labels_changed, 'menu.labels.changed')
+        Publisher.subscribe(self.on_favorites_changed, 'favorites.changed')
+        Publisher.subscribe(self.on_update_available, 'program.update_available')
+        # Publisher.subscribe(self.on_favorite_settings_changed, 'settings.changed.Options.PlaceholderSeparateMenu')
+
+    def on_menu_built(self, *, main_menu: list[MenuName], all_menus: list[CommandCategory], commands: list[Command]):
+        """ Turn the model objects into actual wx menu objects and store them locally.
+        These will be used to populate the menu bar (immediately) and context menus (on demand)
+        :param main_menu: The menus that should appear in the menubar. The associated category object will be modified to include the index.
+        :param all_menus: All CommandCategory objects (derived from the MenuDefinition). Order matters as menus may reference previous menus.
+        :param commands: All command objects
+        """
+        menu_lookup = {x.idx: x for x in all_menus}
+        cmd_lookup = {x.ide: x for x in commands if type(x) is Command}
+        # This function should only be called once. But if it is called multiple times, reset state.
+        self.all_cmd_pairs = []
+        # First, create the wx.Menu objects. This is done for everything. Populate self.menus
+        for item in all_menus:
+            # make_menu will also modify all_cmd_pairs
+            wx_menu = self.make_menu(item, menu_lookup, cmd_lookup)
+            self.menus[item.idx] = wx_menu
+            self.menu_names[item.idx] = item.name
+
+        # Add the appropriate items to self (use Append). Set indices
+        i = 0
+        for idx in main_menu:
+            menu = self.menus[idx]
+            category = menu_lookup[idx]
+            self.Append(menu, category.name)
+            # Need to manually track the id. Searching by name doesn't work if the name can change (translations)
+            # Just counting up is fine as long as there aren't existing menu items, and there shouldn't be.
+            category.menu_idx = i
+            i += 1
+
+        # Create actual bindings for the commands
+        for command in commands:
+            def event_fn(event, cmd=command):
+                #try:
+                #    cmd()
+                #except Exception as e:
+                #    self.handle_error(e)
+                cmd()
+                #raise  Exception("Error.")
+
+            self.Bind(wx.EVT_MENU, event_fn, id=command.ide)
+        # This is the number of pre-defined menu items in favorites; everything past this is a favorite.
+        self._favorite_menu_count = self.menus[MenuName.Favorites].GetMenuItemCount()
+
+    def make_menu(self, menu: CommandCategory, all_menus: dict[MenuName, CommandCategory], cmd_lookup: dict[int, Command]) -> wx.Menu:
+        """ Creates the actual wx.Menu for a given CommandCategory.
+        Still requires references to all data, since this may include submenus.
+        """
+        _menu = wx.Menu()
+        for cmd in menu.commands:
+            if cmd is None:
+                _menu.AppendSeparator()
+            # Submenu
+            elif type(cmd) is MenuName:
+                if cmd not in self.menus:
+                    raise Exception(f"Menu {cmd} referenced before it was created.")
+                submenu = self.menus[cmd]
+                data = all_menus[cmd]
+                _menu.AppendSubMenu(submenu, data.name)
+            # Command
+            elif type(cmd) is CommandName:
+                command = cmd_lookup[cmd]
+                style = wx.ITEM_CHECK if command.checkable else wx.ITEM_NORMAL
+                wx_menuitem = _menu.Append(command.ide, command.name_and_shortcut, command.description, style)
+                #Track for later updates (i.e. translations).
+                self.all_cmd_pairs.append((command, wx_menuitem))
+                #If a cmd is in multiple menus, it will bind multiple times. Is this a problem?
+                if command.update_function:
+                    wx.GetApp().Bind(wx.EVT_UPDATE_UI, command.update_function, id=command.ide)
+        return _menu
+
+    def on_favorites_changed(self, *, favorites: Favorites, settings: Settings):
+        favorites_menu = self.menus[MenuName.Favorites]
+        fav_only = self.menus[MenuName.FavoritesSub]
+        fav_ctx = self.menus[MenuName.FavoritesCtx]
+        place_only = self.menus[MenuName.PlaceholderSub]
+        place_ctx = self.menus[MenuName.PlaceholderCtx]
+        self._create_favorites(favorites)
+        self.Freeze()
+        try:
+            self._reset_favorite_menus()
+            #Rebuild
+            if self.favorites_menu_items:
+                favorites_menu.AppendSeparator()
+            for item in self.favorites_menu_items:
+                favorites_menu.Append(item.ide, item.name)
+                if item.fav.is_placeholder():
+                    place_only.Append(item.ide, item.name)
+                    place_ctx.Append(item.ide, item.name)
+                else:
+                    fav_only.Append(item.ide, item.name)
+                    fav_ctx.Append(item.ide, item.name)
+        finally:
+            self.Thaw()
+        pass
+
+    def _create_favorites(self, favorites: Favorites):
+        """Resets and populates self.favorites_menu_items"""
+        items = favorites.getitems()
+        self.favorites_menu_items = []
+        i = 0
+        for path_key, fav in items:
+            ide = wx.NewId()
+            def event_fn(event: wx.CommandEvent, favorite=fav):
+                try:
+                    raise Exception("Error.")
+                    Publisher.sendMessage('favorite.open', favorite=favorite, window=self)
+                except Exception as e:
+                    self.handle_error(e)
+
+
+            name = fav.displayText()
+            if not name:
+                continue
+
+            self.favorites_menu_items.append(FavoriteMenuItem(ide, name, fav))
+            self.Bind(wx.EVT_MENU, event_fn, id=ide)
+            i += 1
+
+    def _reset_favorite_menus(self):
+        """The favorites menus are always updated by wiping them out and re-building from scratch.
+        Call this within a 'freeze' block. """
+        favorites_menu = self.menus[MenuName.Favorites]
+
+        reset_submenus = (self.menus[MenuName.FavoritesSub], self.menus[MenuName.PlaceholderSub], self.menus[MenuName.FavoritesCtx], self.menus[MenuName.PlaceholderCtx])
+        for menu in reset_submenus:
+            while menu.GetMenuItemCount() > 0:
+                item = menu.FindItemByPosition(0)
+                menu.Delete(item)
+        # self._favorite_menu_count is the number of submenus in the favorites menu;
+        #      entries bigger than this are the favorites themselves.
+        while favorites_menu.GetMenuItemCount() > self._favorite_menu_count:
+            item = favorites_menu.FindItemByPosition(self._favorite_menu_count)
+            favorites_menu.Delete(item)
+
+    def on_favorite_settings_changed(self, settings: Settings):
+        """Updates the various menus that display favorites. Called when settings change or when the favorites change."""
+        #The best way to handle this is likely to alternate between adding favorites directly to the menu and the two sub menus.
+        #Trying to do this is giving me wx free errors.
+        pass
+
+    def on_menu_labels_changed(self, *, categories: list[CommandCategory]):
+        #Commands (i.e. wx.MenuItem s) use stored data. The menu_bar requires indices; wx.Menu references will not work.
+        for (cmd, wx_item) in self.all_cmd_pairs:
+            wx_item.SetItemLabel(cmd.name)
+            wx_item.SetHelp(cmd.description)
+        for category in categories:
+            #Need to use the idx stored in the category (when the bar is created)
+            #Finding by name isn't reliable if the name can change.
+            midx = category.menu_idx
+            if midx != -1:
+                self.SetMenuLabel(midx, category.name)
+
+    # Update available menu
+    def on_language_changed(self):
+        if self.update_menu_item:
+            self.update_menu_item.SetItemLabel(_('&Download'))
+            self.update_menu_item.SetHelp(_('Go to the download site'))
+            self.SetMenuLabel(self.GetMenuCount()-1, _('&New version available!'))
+
+    def on_update_available(self, *, down_url, check_time, version):
+        self.down_url = down_url
+        menu = self.menus[MenuName.Downloads]
+        menu_idx = self.GetMenuCount()
+        self.Append(menu, self.menu_names[MenuName.Downloads])
+        Publisher.sendMessage('menu.item_added', cmd=MenuName.Downloads, idx=menu_idx)
+
+    #TODO: Rename
+    def on_download_update(self):
+        Publisher.sendMessage('program.open_update_site', url=self.down_url)
+
+    # Accessors for specific context menus
+    def open_fit_menu(self):
+        self.PopupMenu(self.menus[MenuName.FitCtx])
+
+    def open_context_menu(self):
+        self.PopupMenu(self.menus[MenuName.ImgCtx])

--- a/quivilib/gui/components/menu_bar.py
+++ b/quivilib/gui/components/menu_bar.py
@@ -185,8 +185,7 @@ class QuiviMenuBar(wx.MenuBar):
         self.Append(menu, self.menu_names[MenuName.Downloads])
         Publisher.sendMessage('menu.item_added', cmd=MenuName.Downloads, idx=menu_idx)
 
-    #TODO: Rename
-    def on_download_update(self):
+    def do_download_update(self):
         Publisher.sendMessage('program.open_update_site', url=self.down_url)
 
     # Accessors for specific context menus

--- a/quivilib/gui/components/menu_bar.py
+++ b/quivilib/gui/components/menu_bar.py
@@ -66,17 +66,6 @@ class QuiviMenuBar(wx.MenuBar):
             category.menu_idx = i
             i += 1
 
-        # Create actual bindings for the commands
-        for command in commands:
-            def event_fn(event, cmd=command):
-                #try:
-                #    cmd()
-                #except Exception as e:
-                #    self.handle_error(e)
-                cmd()
-                #raise  Exception("Error.")
-
-            self.Bind(wx.EVT_MENU, event_fn, id=command.ide)
         # This is the number of pre-defined menu items in favorites; everything past this is a favorite.
         self._favorite_menu_count = self.menus[MenuName.Favorites].GetMenuItemCount()
 
@@ -136,24 +125,17 @@ class QuiviMenuBar(wx.MenuBar):
         """Resets and populates self.favorites_menu_items"""
         items = favorites.getitems()
         self.favorites_menu_items = []
-        i = 0
+        Publisher.sendMessage("menu.reset_favorites")
         for path_key, fav in items:
+            #TODO: Try to preserve IDs instead of creating new ones for old favorites.
             ide = wx.NewId()
-            def event_fn(event: wx.CommandEvent, favorite=fav):
-                try:
-                    raise Exception("Error.")
-                    Publisher.sendMessage('favorite.open', favorite=favorite, window=self)
-                except Exception as e:
-                    self.handle_error(e)
-
 
             name = fav.displayText()
             if not name:
                 continue
 
             self.favorites_menu_items.append(FavoriteMenuItem(ide, name, fav))
-            self.Bind(wx.EVT_MENU, event_fn, id=ide)
-            i += 1
+            Publisher.sendMessage("menu.bind_favorite", ide=ide, fav=fav)
 
     def _reset_favorite_menus(self):
         """The favorites menus are always updated by wiping them out and re-building from scratch.

--- a/quivilib/gui/components/menu_bar.py
+++ b/quivilib/gui/components/menu_bar.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import wx
 import wx.aui
 from pubsub import pub as Publisher
@@ -6,7 +8,7 @@ from quivilib.i18n import _
 from quivilib.model import Favorites
 from quivilib.model.command import Command, CommandCategory
 from quivilib.model.commandenum import MenuName, CommandName
-from quivilib.model.favorites import FavoriteMenuItem
+from quivilib.model.favorites import FavoriteMenuItem, Favorite
 from quivilib.model.settings import Settings
 
 
@@ -26,6 +28,8 @@ class QuiviMenuBar(wx.MenuBar):
         self.all_cmd_pairs: list[tuple[Command, wx.MenuItem]] = []
 
         self.accel_table = None
+
+        self.seen_favorites: dict[tuple[Path, bool], int] = {}
 
         # Set by a background task if there is an update available.
         self.down_url: str | None = None
@@ -127,15 +131,24 @@ class QuiviMenuBar(wx.MenuBar):
         self.favorites_menu_items = []
         Publisher.sendMessage("menu.reset_favorites")
         for path_key, fav in items:
-            #TODO: Try to preserve IDs instead of creating new ones for old favorites.
-            ide = wx.NewId()
-
             name = fav.displayText()
             if not name:
                 continue
+            ide = self._get_favorite_id(fav)
 
             self.favorites_menu_items.append(FavoriteMenuItem(ide, name, fav))
             Publisher.sendMessage("menu.bind_favorite", ide=ide, fav=fav)
+
+    def _get_favorite_id(self, fav: Favorite) -> int:
+        """ Returns a wx id for a specific favorite. This is to avoid generating unnecessary new ids
+        This is probably not needed, but the favorites menu is destroyed each time it changes, so it's not
+        completely impossible that a huge favorites list will cause problems"""
+        k = fav.getKey()
+        if k in self.seen_favorites:
+            return self.seen_favorites[k]
+        new_id = wx.NewId()
+        self.seen_favorites[k] = new_id
+        return new_id
 
     def _reset_favorite_menus(self):
         """The favorites menus are always updated by wiping them out and re-building from scratch.

--- a/quivilib/gui/components/menu_bar.py
+++ b/quivilib/gui/components/menu_bar.py
@@ -231,8 +231,8 @@ class QuiviMenuBar(wx.MenuBar):
         Publisher.sendMessage('program.open_update_site', url=self.down_url)
 
     # Accessors for specific context menus
-    def open_fit_menu(self):
-        self.PopupMenu(self.menus[MenuName.FitCtx])
+    def get_fit_menu(self):
+        return self.menus[MenuName.FitCtx]
 
-    def open_context_menu(self):
-        self.PopupMenu(self.menus[MenuName.ImgCtx])
+    def get_context_menu(self):
+        return self.menus[MenuName.ImgCtx]

--- a/quivilib/gui/components/menu_bar.py
+++ b/quivilib/gui/components/menu_bar.py
@@ -16,15 +16,19 @@ class QuiviMenuBar(wx.MenuBar):
     def __init__(self, style = 0) -> None:
         super().__init__(style)
 
+        self.use_split_favorites: bool|None = None
+
         #List of (id, name) tuples. Filled on the favorites.changed event,
         #used in the file list popup menu
         self.favorites_menu_items: list[FavoriteMenuItem] = []
         self._favorite_menu_count = 0
         """Exists just to prevent adding the menubar item twice, which should be impossible anyway"""
         self.update_menu = None
+
         #Track as a dictionary
         self.menus: dict[MenuName, wx.Menu] = {}
         self.menu_names: dict[MenuName, str] = {}
+        self.menu_idxs: dict[MenuName, int] = {}
         #Used for updating translations dynamically. Pair the actual wx objects and the local definitions.
         self.all_cmd_pairs: list[tuple[Command, wx.MenuItem]] = []
 
@@ -39,7 +43,8 @@ class QuiviMenuBar(wx.MenuBar):
         Publisher.subscribe(self.on_menu_labels_changed, 'menu.labels.changed')
         Publisher.subscribe(self.on_favorites_changed, 'favorites.changed')
         Publisher.subscribe(self.on_update_available, 'program.update_available')
-        # Publisher.subscribe(self.on_favorite_settings_changed, 'settings.changed.Options.PlaceholderSeparateMenu')
+        Publisher.subscribe(self.on_favorite_settings_changed, 'settings.initial_load')
+        Publisher.subscribe(self.on_favorite_settings_changed, 'settings.changed.Options.PlaceholderSeparateMenu')
 
     def on_menu_built(self, *, main_menu: list[MenuName], all_menus: list[CommandCategory], commands: list[Command]):
         """ Turn the model objects into actual wx menu objects and store them locally.
@@ -61,14 +66,18 @@ class QuiviMenuBar(wx.MenuBar):
 
         # Add the appropriate items to self (use Append). Set indices
         i = 0
-        for idx in main_menu:
-            menu = self.menus[idx]
-            category = menu_lookup[idx]
+        for menu_key in main_menu:
+            menu = self.menus[menu_key]
+            category = menu_lookup[menu_key]
             self.Append(menu, category.name)
+            self.menu_idxs[menu_key] = i
             # Need to manually track the id. Searching by name doesn't work if the name can change (translations)
             # Just counting up is fine as long as there aren't existing menu items, and there shouldn't be.
             category.menu_idx = i
             i += 1
+
+        #Need to duplicate as these are supposed to be the same menu
+        self.menu_idxs[MenuName.FavoritesSplit] = self.menu_idxs[MenuName.Favorites]
 
         # This is the number of pre-defined menu items in favorites; everything past this is a favorite.
         self._favorite_menu_count = self.menus[MenuName.Favorites].GetMenuItemCount()
@@ -102,13 +111,17 @@ class QuiviMenuBar(wx.MenuBar):
         return _menu
 
     def on_favorites_changed(self, *, favorites: Favorites, settings: Settings):
+        split = settings.getboolean('Options','PlaceholderSeparateMenu')
         favorites_menu = self.menus[MenuName.Favorites]
-        fav_only = self.menus[MenuName.FavoritesSub]
-        place_only = self.menus[MenuName.PlaceholderSub]
-        fav_dest = [fav_only, place_only]
+        fav_dest = [self.menus[MenuName.FavoritesSub], self.menus[MenuName.PlaceholderSub]]
+        fav_dest2 = [self.menus[MenuName.FavoritesSubSplit], self.menus[MenuName.PlaceholderSubSplit]]
         self._create_favorites(favorites)
         self.Freeze()
         try:
+            if self.use_split_favorites != split:
+                self.use_split_favorites = split
+                self.ChangeFavoriteMenubar(True)
+
             self._reset_favorite_menus()
             #Rebuild
             if self.favorites_menu_items:
@@ -116,9 +129,24 @@ class QuiviMenuBar(wx.MenuBar):
             for item in self.favorites_menu_items:
                 favorites_menu.Append(item.ide, item.name)
                 fav_dest[item.fav.is_placeholder()+0].Append(item.ide, item.name)
+                fav_dest2[item.fav.is_placeholder()+0].Append(item.ide, item.name)
         finally:
             self.Thaw()
         pass
+
+    def ChangeFavoriteMenubar(self, already_frozen: bool):
+        """Find the favorite menu item in the menubar and remove it, then re-add the appropriate one
+        Which menu to use is based on the current value of self.use_split_favorites, so be sure to set that first.
+        An alternate implementation would be to keep the same Fav menubar menu and modify that. However, I absolutely could not get that to work (it caused segfaults)
+        """
+        if not already_frozen:
+            self.Freeze()
+        idx = self.menu_idxs[MenuName.Favorites]
+        replacement = self.menus[MenuName.FavoritesSplit] if self.use_split_favorites else self.menus[MenuName.Favorites]
+        self.Replace(idx, replacement, _('F&avorites'))
+
+        if not already_frozen:
+            self.Thaw()
 
     def _create_favorites(self, favorites: Favorites):
         """Resets and populates self.favorites_menu_items"""
@@ -150,7 +178,10 @@ class QuiviMenuBar(wx.MenuBar):
         Call this within a 'freeze' block. """
         favorites_menu = self.menus[MenuName.Favorites]
 
-        reset_submenus = (self.menus[MenuName.FavoritesSub], self.menus[MenuName.PlaceholderSub])
+        reset_submenus = (
+            self.menus[MenuName.FavoritesSub], self.menus[MenuName.PlaceholderSub],
+            self.menus[MenuName.FavoritesSubSplit], self.menus[MenuName.PlaceholderSubSplit]
+        )
         for menu in reset_submenus:
             while menu.GetMenuItemCount() > 0:
                 item = menu.FindItemByPosition(0)
@@ -165,7 +196,12 @@ class QuiviMenuBar(wx.MenuBar):
         """Updates the various menus that display favorites. Called when settings change or when the favorites change."""
         #The best way to handle this is likely to alternate between adding favorites directly to the menu and the two sub menus.
         #Trying to do this is giving me wx free errors.
-        pass
+        value = settings.getboolean('Options','PlaceholderSeparateMenu')
+        # Note - this is called on saving options, whether or not the value actually changed.
+        if value == self.use_split_favorites:
+            return
+        self.use_split_favorites = value
+        self.ChangeFavoriteMenubar(False)
 
     def on_menu_labels_changed(self, *, categories: list[CommandCategory]):
         #Commands (i.e. wx.MenuItem s) use stored data. The menu_bar requires indices; wx.Menu references will not work.

--- a/quivilib/gui/file_list_view/base.py
+++ b/quivilib/gui/file_list_view/base.py
@@ -14,7 +14,7 @@ class FileListViewBase(object):
     def on_context_menu(self, event):
         menu = wx.Menu()
         #Kinda ugly reference to the MainWindow list of favorites...
-        fav_list: list[FavoriteMenuItem] = self.Parent.Parent.favorites_menu_items
+        fav_list: list[FavoriteMenuItem] = self.Parent.Parent.menu_bar.favorites_menu_items
         for item in fav_list:
             menu.Append(item.ide, item.name)
         #The event handlers were already set by the MainWindow.

--- a/quivilib/gui/main.py
+++ b/quivilib/gui/main.py
@@ -22,6 +22,7 @@ from quivilib.model.command import Command
 from quivilib.model.commandenum import FitSettings
 from quivilib.model.container import Item
 from quivilib.model.container.base import BaseContainer
+from quivilib.model.favorites import Favorite
 from quivilib.model.settings import Settings
 from quivilib.resources import images
 from quivilib.util import error_handler
@@ -84,6 +85,7 @@ class MainWindow(wx.Frame):
         self._busy = False
 
         self.accel_table = None
+        self._bound_favorites: list[int] = []
 
     def bindings_and_subscriptions(self):
         self.panel.Bind(wx.EVT_PAINT, self.on_panel_paint)
@@ -104,6 +106,9 @@ class MainWindow(wx.Frame):
         Publisher.subscribe(self.on_language_changed, 'language.changed')
         Publisher.subscribe(self.on_canvas_changed, 'canvas.changed')
         Publisher.subscribe(self.on_canvas_cursor_changed, 'canvas.cursor.changed')
+        Publisher.subscribe(self.on_menu_built, 'menu.built')
+        Publisher.subscribe(self.on_favorites_reset, 'menu.reset_favorites')
+        Publisher.subscribe(self.on_favorite_bind, 'menu.bind_favorite')
         Publisher.subscribe(self.on_shortcuts_changed, 'menu.shortcuts.changed')
         Publisher.subscribe(self.on_cmd_context_menu, 'menu.context_menu')
         Publisher.subscribe(self.on_settings_loaded, 'settings.loaded')
@@ -266,6 +271,39 @@ class MainWindow(wx.Frame):
 
     def on_canvas_cursor_changed(self, *, cursor: wx.Cursor):
         self.panel.SetCursor(cursor)
+
+    def on_menu_built(self, *, main_menu, all_menus, commands: list[Command]):
+        """ Bind the functions for the menu commands.
+        :param commands: All command objects
+        """
+        # Create actual bindings for the commands
+        for command in commands:
+            def event_fn(event, cmd=command):
+                try:
+                    cmd()
+                except Exception as e:
+                    self.handle_error(e)
+
+            self.Bind(wx.EVT_MENU, event_fn, id=command.ide)
+
+    def on_favorites_reset(self):
+        """ Unbind all favorites and clear out the local cache.
+        This isn't strictly necessary (the menus are destroyed) but it's probably a good idea."""
+        for i in self._bound_favorites:
+            self.Unbind(wx.EVT_MENU, id=i)
+        self._bound_favorites = []
+
+    def on_favorite_bind(self, *, ide: int, fav: Favorite):
+        """ Bind a favorite"""
+
+        def event_fn(event: wx.CommandEvent, favorite=fav):
+            try:
+                Publisher.sendMessage('favorite.open', favorite=favorite, window=self)
+            except Exception as e:
+                self.handle_error(e)
+
+        self.Bind(wx.EVT_MENU, event_fn, id=ide)
+        self._bound_favorites.append(ide)
 
     def on_shortcuts_changed(self, *, accel_table: wx.AcceleratorTable):
         self.accel_table = accel_table

--- a/quivilib/gui/main.py
+++ b/quivilib/gui/main.py
@@ -10,22 +10,22 @@ from pubsub import pub as Publisher
 
 from quivilib import meta
 from quivilib import util
+from quivilib.gui.components.menu_bar import QuiviMenuBar
 from quivilib.gui.components.status_bar import QuiviStatusBar
 from quivilib.gui.debug_cache import DebugCacheDialog
 from quivilib.gui.debug_memory import DebugMemoryDialog
 from quivilib.gui.file_list import FileListPanel
 from quivilib.i18n import _
 from quivilib.interface.canvasadapter import CanvasAdapter
-from quivilib.model import Favorites
 from quivilib.model.canvas import PaintedRegion
-from quivilib.model.command import Command, CommandCategory
-from quivilib.model.commandenum import MenuName, CommandName, FitSettings
+from quivilib.model.command import Command
+from quivilib.model.commandenum import FitSettings
 from quivilib.model.container import Item
 from quivilib.model.container.base import BaseContainer
-from quivilib.model.favorites import FavoriteMenuItem
 from quivilib.model.settings import Settings
 from quivilib.resources import images
 from quivilib.util import error_handler
+
 
 def _handle_error(exception, args, kwargs):
     self = args[0]
@@ -54,7 +54,8 @@ class MainWindow(wx.Frame):
         dt = self.QuiviFileDropTarget(self)
         self.SetDropTarget(dt)
         
-        self.menu_bar = wx.MenuBar()
+        #self.menu_bar = QuiviMenuBar(err_fn = lambda e: self.handle_error(e))
+        self.menu_bar = QuiviMenuBar()
         self.SetMenuBar(self.menu_bar)
         
         self.status_bar = QuiviStatusBar(self)
@@ -81,19 +82,8 @@ class MainWindow(wx.Frame):
         self._last_size = self.get_window_size()
         self._last_pos = self.GetPosition()     # NOTE - This has no effect on Wayland
         self._busy = False
-        #List of (id, name) tuples. Filled on the favorites.changed event,
-        #used in the file list popup menu
-        self.favorites_menu_items: list[FavoriteMenuItem] = []
-        self._favorite_menu_count = 0
-        self.update_menu_item = None
+
         self.accel_table = None
-        #Track as a dictionary
-        self.menus: dict[MenuName, wx.Menu] = {}
-        self.menu_names: dict[MenuName, str] = {}
-        #Used for updating translations dynamically. Pair the actual wx objects and the local definitions.
-        self.all_cmd_pairs: list[tuple[Command, wx.MenuItem]] = []
-        #Set by a background task if there is an update available.
-        self.down_url: str|None = None
 
     def bindings_and_subscriptions(self):
         self.panel.Bind(wx.EVT_PAINT, self.on_panel_paint)
@@ -114,12 +104,8 @@ class MainWindow(wx.Frame):
         Publisher.subscribe(self.on_language_changed, 'language.changed')
         Publisher.subscribe(self.on_canvas_changed, 'canvas.changed')
         Publisher.subscribe(self.on_canvas_cursor_changed, 'canvas.cursor.changed')
-        Publisher.subscribe(self.on_menu_built, 'menu.built')
-        Publisher.subscribe(self.on_menu_labels_changed, 'menu.labels.changed')
         Publisher.subscribe(self.on_shortcuts_changed, 'menu.shortcuts.changed')
         Publisher.subscribe(self.on_cmd_context_menu, 'menu.context_menu')
-        Publisher.subscribe(self.on_favorites_changed, 'favorites.changed')
-        #Publisher.subscribe(self.on_favorite_settings_changed, 'settings.changed.Options.PlaceholderSeparateMenu')
         Publisher.subscribe(self.on_settings_loaded, 'settings.loaded')
         Publisher.subscribe(self.on_open_wallpaper_dialog, 'wallpaper.open_dialog')
         Publisher.subscribe(self.on_open_options_dialog, 'options.open_dialog')
@@ -128,7 +114,6 @@ class MainWindow(wx.Frame):
         Publisher.subscribe(self.on_open_debug_memory_dialog, 'debug.open_memory_dialog')
         Publisher.subscribe(self.on_open_about_dialog, 'about.open_dialog')
         Publisher.subscribe(self.on_open_directory_dialog, 'file_list.open_directory_dialog')
-        Publisher.subscribe(self.on_update_available, 'program.update_available')
         Publisher.subscribe(self.on_bg_color_changed, 'settings.loaded')
         Publisher.subscribe(self.on_bg_color_changed, 'settings.changed.Options.CustomBackground')
         Publisher.subscribe(self.on_bg_color_changed, 'settings.changed.Options.CustomBackgroundColor')
@@ -148,7 +133,7 @@ class MainWindow(wx.Frame):
     def canvas_view(self):
         return CanvasAdapter(self.panel)
     
-    def save(self, settings_lst):
+    def save(self, settings_lst: list[tuple[str, str, str]]):
         perspective = self.aui_mgr.SavePerspective()
         settings_lst.append(('Window', 'Perspective', perspective))
         settings_lst.append(('Window', 'MainWindowX', self._last_pos[0]))
@@ -251,11 +236,11 @@ class MainWindow(wx.Frame):
 
     def on_fit_context_menu(self, event: wx.ContextMenuEvent):
         """Appears on right-clicking the status bar"""
-        self.PopupMenu(self.menus[MenuName.FitCtx])
+        self.menu_bar.open_fit_menu()
         
     def on_cmd_context_menu(self):
         """Appears on executing the bindable 'open context menu' command, e.g. middle/right clicking. """
-        self.PopupMenu(self.menus[MenuName.ImgCtx])
+        self.menu_bar.open_context_menu()
         
     def on_busy(self, *, busy):
         if self._busy == busy:
@@ -282,154 +267,10 @@ class MainWindow(wx.Frame):
     def on_canvas_cursor_changed(self, *, cursor: wx.Cursor):
         self.panel.SetCursor(cursor)
 
-    def on_menu_built(self, *, main_menu: list[MenuName], all_menus: list[CommandCategory], commands: list[Command]):
-        """ Turn the model objects into actual wx menu objects and store them locally.
-        These will be used to populate the menu bar (immediately) and context menus (on demand)
-        :param main_menu: The menus that should appear in the menubar. The associated category object will be modified to include the index.
-        :param all_menus: All CommandCategory objects (derived from the MenuDefinition). Order matters as menus may reference previous menus.
-        :param commands: All command objects
-        """
-        menu_lookup = {x.idx: x for x in all_menus}
-        cmd_lookup = {x.ide: x for x in commands if type(x) is Command}
-        #This function should only be called once. But if it is called multiple times, reset state.
-        self.all_cmd_pairs = []
-        #First, create the wx.Menu objects. This is done for everything. Populate self.menus
-        for item in all_menus:
-            #make_menu will also modify all_cmd_pairs
-            wx_menu = self.make_menu(item, menu_lookup, cmd_lookup)
-            self.menus[item.idx] = wx_menu
-            self.menu_names[item.idx] = item.name
-        
-        #Add the appropriate items to self.menu_bar (use Append). Set indices
-        i = 0
-        for idx in main_menu:
-            menu = self.menus[idx]
-            category = menu_lookup[idx]
-            self.menu_bar.Append(menu, category.name)
-            #Need to manually track the id. Searching by name doesn't work if the name can change (translations)
-            #Just counting up is fine as long as there aren't existing menu items, and there shouldn't be.
-            category.menu_idx = i
-            i += 1
-
-        #Create actual bindings for the commands
-        for command in commands:
-            def event_fn(event, cmd=command):
-                try:
-                    cmd()
-                except Exception as e:
-                    self.handle_error(e)
-            self.Bind(wx.EVT_MENU, event_fn, id=command.ide)
-        #This is the number of pre-defined menu items in favorites; everything past this is a favorite.
-        self._favorite_menu_count = self.menus[MenuName.Favorites].GetMenuItemCount()
-
-    def make_menu(self, menu: CommandCategory, all_menus: dict[MenuName, CommandCategory], cmd_lookup: dict[int, Command]) -> wx.Menu:
-        """ Creates the actual wx.Menu for a given CommandCategory.
-        Still requires references to all data, since this may include submenus.
-        """
-        _menu = wx.Menu()
-        for cmd in menu.commands:
-            if cmd is None:
-                _menu.AppendSeparator()
-            # Submenu
-            elif type(cmd) is MenuName:
-                if cmd not in self.menus:
-                    raise Exception(f"Menu {cmd} referenced before it was created.")
-                submenu = self.menus[cmd]
-                data = all_menus[cmd]
-                _menu.AppendSubMenu(submenu, data.name)
-            # Command
-            elif type(cmd) is CommandName:
-                command = cmd_lookup[cmd]
-                style = wx.ITEM_CHECK if command.checkable else wx.ITEM_NORMAL
-                wx_menuitem = _menu.Append(command.ide, command.name_and_shortcut, command.description, style)
-                #Track for later updates (i.e. translations).
-                self.all_cmd_pairs.append((command, wx_menuitem))
-                #If a cmd is in multiple menus, it will bind multiple times. Is this a problem?
-                if command.update_function:
-                    wx.GetApp().Bind(wx.EVT_UPDATE_UI, command.update_function, id=command.ide)
-        return _menu
-
-    def _reset_favorite_menus(self):
-        """The favorites menus are always updated by wiping them out and re-building from scratch.
-        Call this within a 'freeze' block. """
-        favorites_menu = self.menus[MenuName.Favorites]
-
-        reset_submenus = (self.menus[MenuName.FavoritesSub], self.menus[MenuName.PlaceholderSub], self.menus[MenuName.FavoritesCtx], self.menus[MenuName.PlaceholderCtx])
-        for menu in reset_submenus:
-            while menu.GetMenuItemCount() > 0:
-                item = menu.FindItemByPosition(0)
-                menu.Delete(item)
-        # self._favorite_menu_count is the number of submenus in the favorites menu;
-        #      entries bigger than this are the favorites themselves.
-        while favorites_menu.GetMenuItemCount() > self._favorite_menu_count:
-            item = favorites_menu.FindItemByPosition(self._favorite_menu_count)
-            favorites_menu.Delete(item)
-    def on_favorite_settings_changed(self, settings: Settings):
-        """Updates the various menus that display favorites. Called when settings change or when the favorites change."""
-        #The best way to handle this is likely to alternate between adding favorites directly to the menu and the two sub menus.
-        #Trying to do this is giving me wx free errors.
-        pass
-    def _create_favorites(self, favorites: Favorites):
-        """Resets and populates self.favorites_menu_items"""
-        items = favorites.getitems()
-        self.favorites_menu_items = []
-        i = 0
-        for path_key, fav in items:
-            ide = wx.NewId()
-            def event_fn(event: wx.CommandEvent, favorite=fav):
-                try:
-                    Publisher.sendMessage('favorite.open', favorite=favorite, window=self)
-                except Exception as e:
-                    self.handle_error(e)
-
-            name = fav.displayText()
-            if not name:
-                continue
-
-            self.favorites_menu_items.append(FavoriteMenuItem(ide, name, fav))
-            self.Bind(wx.EVT_MENU, event_fn, id=ide)
-            i += 1
-    def on_favorites_changed(self, *, favorites: Favorites, settings: Settings):
-        favorites_menu = self.menus[MenuName.Favorites]
-        fav_only = self.menus[MenuName.FavoritesSub]
-        fav_ctx = self.menus[MenuName.FavoritesCtx]
-        place_only = self.menus[MenuName.PlaceholderSub]
-        place_ctx = self.menus[MenuName.PlaceholderCtx]
-        self._create_favorites(favorites)
-        self.menu_bar.Freeze()
-        try:
-            self._reset_favorite_menus()
-            #Rebuild
-            if self.favorites_menu_items:
-                favorites_menu.AppendSeparator()
-            for item in self.favorites_menu_items:
-                favorites_menu.Append(item.ide, item.name)
-                if item.fav.is_placeholder():
-                    place_only.Append(item.ide, item.name)
-                    place_ctx.Append(item.ide, item.name)
-                else:
-                    fav_only.Append(item.ide, item.name)
-                    fav_ctx.Append(item.ide, item.name)
-        finally:
-            self.menu_bar.Thaw()
-        pass
-
     def on_shortcuts_changed(self, *, accel_table: wx.AcceleratorTable):
         self.accel_table = accel_table
         self.SetAcceleratorTable(self.accel_table)
 
-    def on_menu_labels_changed(self, *, categories: list[CommandCategory]):
-        #Commands (i.e. wx.MenuItem s) use stored data. The menu_bar requires indices; wx.Menu references will not work.
-        for (cmd, wx_item) in self.all_cmd_pairs:
-            wx_item.SetItemLabel(cmd.name)
-            wx_item.SetHelp(cmd.description)
-        for category in categories:
-            #Need to use the idx stored in the category (when the bar is created)
-            #Finding by name isn't reliable if the name can change.
-            midx = category.menu_idx
-            if midx != -1:
-                self.menu_bar.SetMenuLabel(midx, category.name)
-    
     def on_container_opened(self, *, container: BaseContainer):
         self.SetTitle(f'{container.name} - {meta.APPNAME}')
     
@@ -439,10 +280,6 @@ class MainWindow(wx.Frame):
     def on_language_changed(self):
         self.aui_mgr.GetPane('file_list').Caption(_('Files'))
         self.aui_mgr.Update()
-        if self.update_menu_item:
-            self.update_menu_item.SetItemLabel(_('&Download'))
-            self.update_menu_item.SetHelp(_('Go to the download site'))
-            self.menu_bar.SetMenuLabel(self.menu_bar.GetMenuCount()-1, _('&New version available!'))
     
     def on_open_wallpaper_dialog(self, *, choices: list[str], color: wx.Colour):
         from quivilib.gui.wallpaper import WallpaperDialog
@@ -488,16 +325,9 @@ class MainWindow(wx.Frame):
         dialog = AboutDialog(self)
         dialog.ShowModal()
         dialog.Destroy()
-        
-    def on_update_available(self, *, down_url, check_time, version):
-        self.down_url = down_url
-        menu = self.menus[MenuName.Downloads]
-        menu_idx = self.menu_bar.GetMenuCount()
-        self.menu_bar.Append(menu, self.menu_names[MenuName.Downloads])
-        Publisher.sendMessage('menu.item_added', cmd=MenuName.Downloads, idx=menu_idx)
 
     def on_download_update(self):
-        Publisher.sendMessage('program.open_update_site', url=self.down_url)
+        self.menu_bar.on_download_update()
 
     def on_bg_color_changed(self, *, settings: Settings):
         if settings.get('Options', 'CustomBackground') == '1':

--- a/quivilib/gui/main.py
+++ b/quivilib/gui/main.py
@@ -241,11 +241,12 @@ class MainWindow(wx.Frame):
 
     def on_fit_context_menu(self, event: wx.ContextMenuEvent):
         """Appears on right-clicking the status bar"""
-        self.menu_bar.open_fit_menu()
+        # Note - on Windows, it appears to be necessary to call PopupMenu here, not in the menubar. Linux doesn't care.
+        self.PopupMenu(self.menu_bar.get_fit_menu())
         
     def on_cmd_context_menu(self):
         """Appears on executing the bindable 'open context menu' command, e.g. middle/right clicking. """
-        self.menu_bar.open_context_menu()
+        self.PopupMenu(self.menu_bar.get_context_menu())
         
     def on_busy(self, *, busy):
         if self._busy == busy:

--- a/quivilib/gui/main.py
+++ b/quivilib/gui/main.py
@@ -364,8 +364,8 @@ class MainWindow(wx.Frame):
         dialog.ShowModal()
         dialog.Destroy()
 
-    def on_download_update(self):
-        self.menu_bar.on_download_update()
+    def do_download_update(self):
+        self.menu_bar.do_download_update()
 
     def on_bg_color_changed(self, *, settings: Settings):
         if settings.get('Options', 'CustomBackground') == '1':

--- a/quivilib/gui/main.py
+++ b/quivilib/gui/main.py
@@ -54,8 +54,7 @@ class MainWindow(wx.Frame):
 
         dt = self.QuiviFileDropTarget(self)
         self.SetDropTarget(dt)
-        
-        #self.menu_bar = QuiviMenuBar(err_fn = lambda e: self.handle_error(e))
+
         self.menu_bar = QuiviMenuBar()
         self.SetMenuBar(self.menu_bar)
         

--- a/quivilib/gui/options.py
+++ b/quivilib/gui/options.py
@@ -58,7 +58,7 @@ class OptionsDialog(wx.Dialog):
         
         self.lang_lst.SetColumnWidth(0, self.lang_lst.GetClientSize()[0])
         
-        self.shortcuts = {}
+        self.shortcuts: dict[Command, list[Shortcut]] = {}
         for cmd in self.commands:
             if cmd is not None:
                 self.shortcuts[cmd] = cmd.shortcuts[:]
@@ -83,7 +83,7 @@ class OptionsDialog(wx.Dialog):
         self.placeholder_autodelete_chk = wx.CheckBox(self.viewing_pane, -1, _("Delete placeholders when opening"))
         self.placeholder_single_chk = wx.CheckBox(self.viewing_pane, -1, _("Only allow a single placeholder"))
         self.placeholder_autoopen_chk = wx.CheckBox(self.viewing_pane, -1, _("Automatically jump to placeholder page on open"))
-        #self.placeholder_separate_chk = wx.CheckBox(self.viewing_pane, -1, _("Use separate menus for favorites and placeholders"))
+        self.placeholder_separate_chk = wx.CheckBox(self.viewing_pane, -1, _("Use separate menus for favorites and placeholders"))
     def _init_commands(self):
         self.commands_label = wx.StaticText(self.keys_pane, -1, _("Commands"))
         self.commands_lst = wx.ListBox(self.keys_pane, -1, choices=[])
@@ -185,8 +185,8 @@ class OptionsDialog(wx.Dialog):
         self.placeholder_single_chk.SetValue(placeholder_single)
         placeholder_autoopen = (self.settings.get('Options', 'PlaceholderAutoOpen') == '1')
         self.placeholder_autoopen_chk.SetValue(placeholder_autoopen)
-        #placeholder_separate = (self.settings.get('Options', 'PlaceholderSeparateMenu') == '1')
-        #self.placeholder_separate_chk.SetValue(placeholder_separate)
+        placeholder_separate = (self.settings.get('Options', 'PlaceholderSeparateMenu') == '1')
+        self.placeholder_separate_chk.SetValue(placeholder_separate)
         
         self.settings_local_chk.SetValue(self.save_locally)
         
@@ -302,7 +302,7 @@ class OptionsDialog(wx.Dialog):
         viewing_sizer.Add(self.placeholder_autodelete_chk, 0, wx.LEFT|wx.RIGHT|wx.TOP, 5)
         viewing_sizer.Add(self.placeholder_single_chk, 0, wx.LEFT|wx.RIGHT|wx.TOP, 5)
         viewing_sizer.Add(self.placeholder_autoopen_chk, 0, wx.LEFT|wx.RIGHT|wx.TOP, 5)
-        #viewing_sizer.Add(self.placeholder_separate_chk, 0, wx.LEFT|wx.RIGHT|wx.TOP, 5)
+        viewing_sizer.Add(self.placeholder_separate_chk, 0, wx.LEFT|wx.RIGHT|wx.TOP, 5)
         self.viewing_pane.SetSizer(viewing_sizer)
 
     def on_fit_select(self, event): # wxGlade: OptionsDialog.<event_handler>
@@ -346,7 +346,7 @@ class OptionsDialog(wx.Dialog):
         self.shortcuts = {}
         for cmd in self.commands:
             if cmd.default_shortcuts:
-                self.shortcuts[cmd] = [cmd.default_shortcuts]
+                self.shortcuts[cmd] = cmd.default_shortcuts[:]
             else:
                 self.shortcuts[cmd] = []
         sel = self.commands_lst.GetSelection()
@@ -385,7 +385,7 @@ class OptionsDialog(wx.Dialog):
         opt.placeholder_delete = self.placeholder_autodelete_chk.GetValue()
         opt.placeholder_single = self.placeholder_single_chk.GetValue()
         opt.placeholder_autoopen = self.placeholder_autoopen_chk.GetValue()
-        #opt.placeholder_separate = self.placeholder_separate_chk.GetValue()
+        opt.placeholder_separate = self.placeholder_separate_chk.GetValue()
         opt.shortcuts = self.shortcuts
         opt.always_drag = self.always_drag_chk.GetValue()
         opt.drag_threshold = self.threshold_txt.GetValue()

--- a/quivilib/model/commandenum.py
+++ b/quivilib/model/commandenum.py
@@ -220,7 +220,5 @@ class MenuName(StrEnum):
     ZoomSub = '_zoomSub'
     RotateSub = '_rotateSub'
     FavoritesSub = '_favoriteSub'
-    FavoritesCtx = '_favoriteCtx'
     PlaceholderSub = '_placeholderSub'
-    PlaceholderCtx = '_placeholderCtx'
 #

--- a/quivilib/model/commandenum.py
+++ b/quivilib/model/commandenum.py
@@ -210,6 +210,7 @@ class MenuName(StrEnum):
     Folder = 'fold'
     View = 'view'
     Favorites = 'fav'
+    FavoritesSplit = 'favS'
     Help = 'help'
     Downloads = 'download'      #Conditionally in the menu bar
     Debug = 'debug'     #Debug mode only
@@ -221,4 +222,6 @@ class MenuName(StrEnum):
     RotateSub = '_rotateSub'
     FavoritesSub = '_favoriteSub'
     PlaceholderSub = '_placeholderSub'
+    FavoritesSubSplit = '_favoriteSplit'
+    PlaceholderSubSplit = '_placeholderSplit'
 #

--- a/quivilib/model/commandlist.py
+++ b/quivilib/model/commandlist.py
@@ -392,6 +392,24 @@ class MenuDefinitionList():
         fav_sub = MenuDefinition(MenuName.FavoritesSub, 'Favorites', (
             # Deliberately empty
         ))
+        placeholder_sub_split = MenuDefinition(MenuName.PlaceholderSubSplit, 'Placeholders', (
+            # Deliberately empty
+        ))
+        fav_sub_split = MenuDefinition(MenuName.FavoritesSubSplit, 'Favorites', (
+            # Deliberately empty
+        ))
+        favorites_split_menu = MenuDefinition(MenuName.FavoritesSplit, 'F&avorites', (
+            # In theory these should be in the sub menus, but the main purpose of this is to make long fav lists easier to deal with
+            # And there's a lot more room here.
+            CommandName.ADD_FAVORITES,
+            CommandName.ADD_PLACEHOLDER,
+            CommandName.REMOVE_FAVORITES,
+            CommandName.REMOVE_PLACEHOLDER,
+            None,
+            #It is not possible to use fav_sub etc twice.
+            MenuName.FavoritesSubSplit,
+            MenuName.PlaceholderSubSplit,
+        ))
         help_menu = MenuDefinition(MenuName.Help, '&Help', (
             CommandName.HELP,
             CommandName.FEEDBACK,
@@ -461,7 +479,7 @@ class MenuDefinitionList():
             self.menubar_menus = self.menubar_menus + (debug_menu,)
         self.menu_list = (
             file_menu, folder_menu, view_menu, help_menu, download_menu,
-            fav_sub, placeholder_sub, favorites_menu,
+            fav_sub, placeholder_sub, fav_sub_split, placeholder_sub_split, favorites_menu, favorites_split_menu,
             zoom_sub, rotate_sub,
             fit_menu, img_context,
             debug_menu,

--- a/quivilib/model/commandlist.py
+++ b/quivilib/model/commandlist.py
@@ -301,7 +301,7 @@ class CommandDefinitionList():
                                     [])
 
             cat_name = __('Download')
-            yield CommandDefinition(CommandName.DOWNLOAD_NEW, cat_name, control.view.on_download_update,
+            yield CommandDefinition(CommandName.DOWNLOAD_NEW, cat_name, control.view.do_download_update,
                                     __('&Download'), __('Go to the download site'),
                                     [],
                                     flags=CommandFlags.NOMENU)

--- a/quivilib/model/commandlist.py
+++ b/quivilib/model/commandlist.py
@@ -421,12 +421,6 @@ class MenuDefinitionList():
             CommandName.ROTATE_COUNTER_CLOCKWISE,
         ))
         # Context menus
-        fav_ctx = MenuDefinition(MenuName.FavoritesCtx, 'Favorites', (
-            #Deliberately empty
-        ))
-        placeholder_ctx = MenuDefinition(MenuName.PlaceholderCtx, 'Placeholders', (
-            #Deliberately empty
-        ))
         fit_menu = MenuDefinition(MenuName.FitCtx, empty, (
             CommandName.ZOOM_NONE,
             CommandName.ZOOM_WIDTH,
@@ -452,8 +446,8 @@ class MenuDefinitionList():
             CommandName.FULL_SCREEN,
             CommandName.SHOW_FILE_LIST,
             None,
-            MenuName.FavoritesCtx,
-            MenuName.PlaceholderCtx,
+            MenuName.FavoritesSub,
+            MenuName.PlaceholderSub,
             None,
             CommandName.OPTIONS,
             CommandName.HELP,
@@ -468,7 +462,7 @@ class MenuDefinitionList():
         self.menu_list = (
             file_menu, folder_menu, view_menu, help_menu, download_menu,
             fav_sub, placeholder_sub, favorites_menu,
-            zoom_sub, rotate_sub, fav_ctx, placeholder_ctx,
+            zoom_sub, rotate_sub,
             fit_menu, img_context,
             debug_menu,
         )

--- a/quivilib/model/settings.py
+++ b/quivilib/model/settings.py
@@ -33,7 +33,8 @@ class Settings(RawConfigParser):
             _parseError()
         self.__defaults = self._load_defaults()
         Publisher.sendMessage('settings.changed', settings=self)
-        
+        Publisher.sendMessage('settings.initial_load', settings=self)
+
     def _load_defaults(self):
         defaults = (
           ('Options', 'FitType', FitSettings.FitType.WIDTH_IF_LARGER),


### PR DESCRIPTION
Add configuration option to use separate favorites/placeholders submenus in the menubar.